### PR TITLE
Gráfico de ventas por mes

### DIFF
--- a/src/components/AdminDashInicio/DashboardInicio.jsx
+++ b/src/components/AdminDashInicio/DashboardInicio.jsx
@@ -5,10 +5,6 @@ import React, { useEffect, useState } from "react";
 import { CssBaseline, Container, Typography, Grid, Paper } from "@mui/material";
 import VentasCharts from "../GraficoVentas/VentasCharts";
 
-const ventasMensualesHardcodeadas = [
-  1500, 1200, 2000, 1800, 2500, 2200, 1900, 2800, 3200, 3000, 3500, 4000,
-];
-
 const DashboardInicio = () => {
   const [numUsersReg, setNumUsersReg] = useState(null);
   const [numProductos, setNumProductos] = useState(null);
@@ -52,6 +48,38 @@ const DashboardInicio = () => {
     };
     fetchUsersAndProducts();
   }, []);
+
+  const [ventasPorMes, setVentasPorMes] = useState([]);
+
+  useEffect(() => {
+    const getVentasPorMes = () => {
+      if (!totalVentas) return;
+
+      const carritosConVentas = totalVentas.filter(
+        (carrito) => carrito.status === true
+      );
+
+      const ventasAgrupadasPorMes = carritosConVentas.reduce((acc, carrito) => {
+        const fecha = new Date(carrito.fecha);
+        const mes = fecha.getMonth();
+
+        if (!acc[mes]) {
+          acc[mes] = 0;
+        }
+        acc[mes] += carrito.items.length;
+        return acc;
+      }, {});
+
+      const arrayVentasPorMes = Array.from(
+        { length: 12 },
+        (_, index) => ventasAgrupadasPorMes[index] || 0
+      );
+
+      setVentasPorMes(arrayVentasPorMes);
+    };
+
+    getVentasPorMes();
+  }, [totalVentas]);
 
   return (
     <>
@@ -121,7 +149,7 @@ const DashboardInicio = () => {
               <Typography variant="h6" gutterBottom>
                 Ventas Mensuales
               </Typography>
-              <VentasCharts ventasMensuales={ventasMensualesHardcodeadas} />
+              <VentasCharts ventasMensuales={ventasPorMes} />
             </Paper>
           </Grid>
         </Grid>


### PR DESCRIPTION
-Grafico de ventas por mes en funcionamiento: El grafico debería mostrar y agrupar las ventas por mes en base a la propiedad fecha.
A implementar: Que cuando el gráfico llegue al último mes se reinicie y que guarde de alguna forma el grafico del año anterior