### PR TITLE
Lógica de reset del grafico de ventas

### DIFF
--- a/src/components/AdminDashInicio/DashboardInicio.jsx
+++ b/src/components/AdminDashInicio/DashboardInicio.jsx
@@ -70,10 +70,20 @@ const DashboardInicio = () => {
         return acc;
       }, {});
 
-      const arrayVentasPorMes = Array.from(
-        { length: 12 },
-        (_, index) => ventasAgrupadasPorMes[index] || 0
+      const fechaUltimoCarrito = carritosConVentas.reduce(
+        (maxFecha, carrito) => {
+          const fechaCarrito = new Date(carrito.fecha);
+          return fechaCarrito > maxFecha ? fechaCarrito : maxFecha;
+        },
+        new Date(0)
       );
+
+      const arrayVentasPorMes = Array.from({ length: 12 }, (_, index) => {
+        if (index <= fechaUltimoCarrito.getMonth()) {
+          return ventasAgrupadasPorMes[index] || 0;
+        }
+        return 0;
+      });
 
       setVentasPorMes(arrayVentasPorMes);
     };


### PR DESCRIPTION
Implementación de lógica de reseteo cuando la fecha de la ultima venta sea del mes siguiente al ultimo, es decir cuando el numero del mes sea menor al anterior, osea 0(enero) luego de 11(diciembre). El gráfico debería funcionar normalmente al cambiar de año.
-A implementar: un historial de gráficos para cada año que vaya pasando